### PR TITLE
Set correct version to integration info via const.py

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,6 +16,7 @@ jobs:
       - name: Patch manifest and zip
         run: |
           sed -i 's/v0.0.0/${{ steps.version.outputs.version }}/' custom_components/ote_rate/manifest.json
+          sed -i 's/v0.0.0/${{ steps.version.outputs.version }}/' custom_components/ote_rate/const.py
         
           cd custom_components/ote_rate/
           zip ../../ote_rate.zip ./* translations/* -x '.*'

--- a/custom_components/ote_rate/const.py
+++ b/custom_components/ote_rate/const.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Final
 
 DOMAIN: Final = "ote_rate"
-VERSION: Final = "0.2.4"
+VERSION: Final = "v0.0.0"
 ATTR_MANUFACTURER: Final = "OTE"
 ATTRIBUTION = "https://www.ote-cr.cz/cs/kratkodobe-trhy/elektrina/denni-trh"
 


### PR DESCRIPTION
There was incorrect version shown in the integration overview
![image](https://github.com/grinco/ote_rate/assets/10993234/5ecdc9ab-c8d2-4f9a-b608-a133f6269e74)
